### PR TITLE
Initialise datepicker with existing event date

### DIFF
--- a/src/app/events/edit/edit.component.ts
+++ b/src/app/events/edit/edit.component.ts
@@ -31,6 +31,7 @@ export class EditComponent implements OnInit {
       field: document.getElementById('datepicker'),
       format: 'D MMMM YYYY'
     });
+    picker.setDate(this.event.date);
   }
 
   // Horrible, horrible ...


### PR DESCRIPTION
The input value is not set before the date picker is initialised, so I've added a line to set the current value in ngOnInit()